### PR TITLE
Added package.json for easier npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "atvimg",
+  "version": "1.0.0",
+  "description": "3D parallax icons like those in Apple TV.",
+  "main": "atvImg.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/drewwilson/atvImg.git"
+  },
+  "keywords": [
+    "html",
+    "parallax",
+    "icon"
+  ],
+  "author": "Drew Wilson",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/drewwilson/atvImg/issues"
+  },
+  "homepage": "https://github.com/drewwilson/atvImg#readme"
+}


### PR DESCRIPTION
Hi,

I would really appreciate if you could publish this library to npm (or bower for that matter). For your convenience, I created a `package.json` file that is ready to go.

Even if you don't plan to publish this module to npm, having a `package.json` would still allow people to install this library using `npm install drewwilson/atvImg`, which would be very helpful for people who have lots of dependencies to manage.
