### PR TITLE
Add background to shadow & change shadows to em.

### DIFF
--- a/atvImg.css
+++ b/atvImg.css
@@ -1,24 +1,24 @@
 .atvImg {
-	border-radius: 5px;
+	border-radius: 5;
 	transform-style: preserve-3d;
 	-webkit-tap-highlight-color: rgba(#000,0);
 }
 
 .atvImg img {
 	border-radius: 5px;
-	box-shadow: 0 2px 8px rgba(14,21,47,0.25);
+	box-shadow: 0 0.125em 0.5em rgba(14,21,47,0.25);
 }
 
 .atvImg-container {
 	position: relative;
 	width: 100%;
 	height: 100%;
-	border-radius: 5px;
+	border-radius: 5;
 	transition: all 0.2s ease-out;
 }
 
 .atvImg-container.over .atvImg-shadow {
-	box-shadow: 0 45px 100px rgba(14,21,47,0.4), 0 16px 40px rgba(14,21,47,0.4);
+	box-shadow: 0 2.8em 6.25em rgba(14,21,47,0.4), 0 1em 2.5em rgba(14,21,47,0.4);
 }
 
 .atvImg-layers {
@@ -49,8 +49,9 @@
 	left: 5%;
 	width: 90%;
 	height: 90%;
+	background:rgba(14,21,47,0.6);
 	transition: all 0.2s ease-out;
-	box-shadow: 0 8px 30px rgba(14,21,47,0.6);
+	box-shadow: 0 0.5em 1.88em rgba(14,21,47,0.6);
 }
 
 .atvImg-shine {


### PR DESCRIPTION
Adding a background to the shadow improves the way things look while the layer images are loading. Meanwhile, using em for the shadow helps the shadow scale while the container's font size scales.

I could see not using em for the shadow dimensions, but I really think the shadow should have a background.
